### PR TITLE
Make `DescriptionBuilder` functions use null-terminated `CString` instead of passing the `&str` directly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(ptr_metadata)]
 
+use std::ffi::CString;
 use std::{
     ffi::c_void,
     ptr::{from_raw_parts_mut, Pointee},
@@ -149,16 +150,19 @@ mod callbacks {
 pub struct DescriptionBuilder(sys::PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription);
 impl DescriptionBuilder {
     pub fn set_application_name(&mut self, name: &str) {
+        let name = CString::new(name).unwrap();
         unsafe {
             (self.0)(1, name.as_ptr());
         }
     }
     pub fn set_application_version(&mut self, name: &str) {
+        let name = CString::new(name).unwrap();
         unsafe {
             (self.0)(2, name.as_ptr());
         }
     }
     pub fn set(&mut self, index: u32, name: &str) {
+        let name = CString::new(name).unwrap();
         unsafe {
             (self.0)(0x10000 + index, name.as_ptr());
         }

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -1,7 +1,7 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 
-use std::ffi::c_void;
+use std::ffi::{c_char, c_void};
 
 pub const GFSDK_Aftermath_Version_API: u32 = 0x0000214; // Version 2.20
 
@@ -22,7 +22,7 @@ pub type PFN_GFSDK_Aftermath_ResolveMarkerCb = unsafe extern "C" fn(
     marker_size: *mut u32,
 );
 pub type PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription =
-    unsafe extern "C" fn(key: u32, value: *const u8);
+    unsafe extern "C" fn(key: u32, value: *const c_char);
 pub type PFN_GFSDK_Aftermath_GpuCrashDumpDescriptionCb = unsafe extern "C" fn(
     add_value: PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription,
     p_user_data: *mut c_void,


### PR DESCRIPTION
`typedef void (GFSDK_AFTERMATH_CALL *PFN_GFSDK_Aftermath_AddGpuCrashDumpDescription)(uint32_t key, const char* value);`

the string is just a plain C-String, so it must be null terminated :)